### PR TITLE
Publish docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,35 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: [main]
+    tags: [v*]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: image_meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.image_meta.outputs.tags }}
+          labels: ${{ steps.image_meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
     tags: [v*]
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   docker:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [main]
     tags: [v*]
-  pull_request:
-    types: [opened, synchronize]
 
 jobs:
   docker:


### PR DESCRIPTION
Publish docker images automatically when pushing to main or tagging a new version

Config copied from this other PR:
https://github.com/cowprotocol/watch-tower/pull/61

# Test 
Temporarily, I forced actions to run on PR commits. This is how I tested the deployment (see https://github.com/cowprotocol/cms/pull/8/commits/eb2b675e396c010c5298cf2f8a250d33e7d3f0e7):
- Deployment: https://github.com/cowprotocol/cms/actions/runs/6372812813

See published package: https://github.com/cowprotocol/cms/pkgs/container/cms