### PR TITLE
Create library @cowprotocol/cms

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+*
+!README.md
+!dist/**/*

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 *
 !README.md
+!src/lib/README.md
 !dist/**/*

--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
   "scripts": {
     "dev": "strapi develop",
     "start": "strapi start",
-    "build": "npm run build:strapi && npm run build:lib",
+    "build": "npm run types && npm run build:strapi && npm run build:lib",
     "build:strapi": "npx tsc -p tsconfig.lib.json",
     "build:lib": "npx tsc -p tsconfig.lib.json",
     "strapi": "strapi",
-    "types": "npx openapi-typescript src/extensions/documentation/documentation/1.0.0/full_documentation.json -o src/gen/types.ts"
+    "types": "npx openapi-typescript src/extensions/documentation/documentation/1.0.0/full_documentation.json -o src/gen/types.ts",
+    "prepublish": "npm run build"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
-  "name": "cms",
-  "private": true,
-  "version": "0.1.0",
-  "description": "A Strapi application",
+  "name": "@cowprotocol/cms",
+  "version": "0.1.0-rc.0",
+  "description": "Cow Protocol CMS",
   "main": "dist/lib.js",
   "types": "dist/lib.d.ts",
+  "source": "src/lib.ts",
+  "exports": {
+    "require": "./dist/lib.js",
+    "default": "./dist/lib.js"
+  },
+  "license": "(MIT OR Apache-2.0)",
   "scripts": {
     "dev": "strapi develop",
     "start": "strapi start",
@@ -16,8 +21,8 @@
     "types:local": "npx openapi-typescript http://localhost:1337/api/docs/openapi.json -o src/gen/types.ts",
     "types:prod": "npx openapi-typescript https://cms.cow.fi/api/docs/openapi.json -o src/gen/types.ts"
   },
-  "devDependencies": {},
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "@strapi/plugin-documentation": "4.13.3",
     "@strapi/plugin-i18n": "4.13.3",
     "@strapi/plugin-users-permissions": "4.13.3",
@@ -35,6 +40,5 @@
   "engines": {
     "node": ">=16.0.0 <=20.x.x",
     "npm": ">=6.0.0"
-  },
-  "license": "MIT"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "strapi develop",
     "start": "strapi start",
-    "build": "strapi build",
+    "build": "npm run build:strapi && npm run build:lib",
+    "build:strapi": "npx tsc -p tsconfig.lib.json",
     "build:lib": "npx tsc -p tsconfig.lib.json",
     "strapi": "strapi",
     "types": "npm run types:prod",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
     "build:strapi": "npx tsc -p tsconfig.lib.json",
     "build:lib": "npx tsc -p tsconfig.lib.json",
     "strapi": "strapi",
-    "types": "npm run types:prod",
-    "types:local": "npx openapi-typescript http://localhost:1337/api/docs/openapi.json -o src/gen/types.ts",
-    "types:prod": "npx openapi-typescript https://cms.cow.fi/api/docs/openapi.json -o src/gen/types.ts"
+    "types": "npx openapi-typescript src/extensions/documentation/documentation/1.0.0/full_documentation.json -o src/gen/types.ts"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
   "private": true,
   "version": "0.1.0",
   "description": "A Strapi application",
+  "main": "dist/lib.js",
+  "types": "dist/lib.d.ts",
   "scripts": {
     "dev": "strapi develop",
     "start": "strapi start",
     "build": "strapi build",
+    "build:lib": "npx tsc -p tsconfig.lib.json",
     "strapi": "strapi",
     "types": "npm run types:prod",
     "types:local": "npx openapi-typescript http://localhost:1337/api/docs/openapi.json -o src/gen/types.ts",

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,1 @@
+export * from "./gen/types";

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "include": ["src/lib.ts", "src/gen/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "target": "es2016",
+    "module": "commonjs",
+    "lib": ["es2018", "dom"],
+    "sourceMap": true,
+    "declaration": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noImplicitReturns": true,
+    "noUnusedParameters": true,
+    "strictNullChecks": true
+  }
+}


### PR DESCRIPTION
Adapts the package.json to allow to build a new library `@cowprotocol/cms`
Includes also the typescript configuration.

After the changes, I published a new library:
https://www.npmjs.com/package/@cowprotocol/cms

For that, I used `npm publish --access public`

## Caveats
It has given me a headache (as always we create a new library) when I wanted to have a custom README.md
As this library is internal, allow me to use the strapi README also for the library. Ideally I would love to override it with another one, but NPM don't make it very easy! 

## Test
Build Library:
`yarn build:lib`

Pretend you publish the library, see the output of:
`npm publish --dry-run`