### PR TITLE
Publish client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cms",
-  "version": "0.1.0-rc.2",
+  "version": "0.1.0-rc.4",
   "description": "Cow Protocol CMS",
   "main": "dist/lib.js",
   "types": "dist/lib.d.ts",
@@ -18,7 +18,7 @@
     "build:lib": "npx tsc -p tsconfig.lib.json",
     "strapi": "strapi",
     "types": "npx openapi-typescript src/extensions/documentation/documentation/1.0.0/full_documentation.json -o src/gen/types.ts",
-    "prepublish": "npm run build"
+    "prepare": "npm run build"
   },
   "dependencies": {
     "openapi-fetch": "^0.9.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cms",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "description": "Cow Protocol CMS",
   "main": "dist/lib.js",
   "types": "dist/lib.d.ts",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "types": "npx openapi-typescript src/extensions/documentation/documentation/1.0.0/full_documentation.json -o src/gen/types.ts",
     "prepublish": "npm run build"
   },
-  "dependencies": {},
+  "dependencies": {
+    "openapi-fetch": "^0.9.3"
+  },
   "devDependencies": {
     "@strapi/plugin-documentation": "4.13.3",
     "@strapi/plugin-i18n": "4.13.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cms",
-  "version": "0.1.0-rc.0",
+  "version": "0.1.0-rc.1",
   "description": "Cow Protocol CMS",
   "main": "dist/lib.js",
   "types": "dist/lib.d.ts",

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,1 +1,18 @@
 export * from "./gen/types";
+
+import createClient from "openapi-fetch";
+import type { paths, components } from "./gen/types";
+
+export interface CmsClientOptions {
+  url?: string;
+}
+
+/**
+ * Open API Fetch client. See docs for usage https://openapi-ts.pages.dev/openapi-fetch/
+ */
+export function CmsClient(options: CmsClientOptions = {}) {
+  const { url = "https://cms.cow.fi/api" } = options;
+  return createClient<paths>({
+    baseUrl: url,
+  });
+}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,7 +1,7 @@
 export * from "./gen/types";
 
 import createClient from "openapi-fetch";
-import type { paths, components } from "./gen/types";
+import type { paths } from "./gen/types";
 
 export interface CmsClientOptions {
   url?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6392,6 +6392,18 @@ open@^8.0.9:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
+openapi-fetch@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/openapi-fetch/-/openapi-fetch-0.9.3.tgz#37c1dbde7faec885eaa40f351cab1c231b794761"
+  integrity sha512-tC1NDn71vJHeCzu+lYdrnIpgRt4GxR0B4eSwXNb15ypWpZcpaEOwHFkoz8FcfG5Fvqkz2P0Fl9zQF1JJwBjuvA==
+  dependencies:
+    openapi-typescript-helpers "^0.0.7"
+
+openapi-typescript-helpers@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.7.tgz#1d0ead67c35864d189c2cb2d0556854ccbb16c38"
+  integrity sha512-7nwlAtdA1fULipibFRBWE/rnF114q6ejRYzNvhdA/x+qTWAZhXGLc/368dlwMlyJDvCQMCnADjpzb5BS5ZmNSA==
+
 openapi-typescript@^6.7.5:
   version "6.7.5"
   resolved "https://registry.yarnpkg.com/openapi-typescript/-/openapi-typescript-6.7.5.tgz#3e7f0d080d540396ef8db3df4ed07e1a4a5bb1d8"


### PR DESCRIPTION
Publishes a client to access the CMS

Make uses of the new CMS types, and build a client using `openapi-fetch`, which is the companion library for  `openapi-typescript`

