### PR TITLE
Allow to set your own headers and your API KEY

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -5,14 +5,28 @@ import type { paths } from "./gen/types";
 
 export interface CmsClientOptions {
   url?: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
 }
 
 /**
  * Open API Fetch client. See docs for usage https://openapi-ts.pages.dev/openapi-fetch/
  */
 export function CmsClient(options: CmsClientOptions = {}) {
-  const { url = "https://cms.cow.fi/api" } = options;
+  const {
+    url = "https://cms.cow.fi/api",
+    headers: baseHeaders = {},
+    apiKey,
+  } = options;
   return createClient<paths>({
     baseUrl: url,
+    headers: {
+      ...baseHeaders,
+      ...(apiKey
+        ? {
+            Authorization: "Bearer " + apiKey,
+          }
+        : {}),
+    },
   });
 }


### PR DESCRIPTION
Add possibility to the CMS lib to add an API KEY and some optional headers