### PR TITLE
chore: up node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 RUN yarn build
 
 # Creating final production image
-FROM node:16-alpine
+FROM node:18-alpine
 RUN apk add --no-cache vips-dev
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}


### PR DESCRIPTION
The build fails because of node version: 
https://github.com/cowprotocol/cms/actions/runs/9578191698/job/26407909811#step:5:513