### PR TITLE
fix: search notifications for account with any case

### DIFF
--- a/src/api/notification/services/notification.ts
+++ b/src/api/notification/services/notification.ts
@@ -50,14 +50,17 @@ export default factories.createCoreService(MODULE_ID, ({ strapi }) => {
     },
     async getNotificationList(account: string) {
       const push = false
+      const templateFilter = notificationsTemplateFilter(push)
       const notifications = await strapi.entityService.findMany(
         MODULE_ID,
         {
           start: 0,
           limit: 50,
           filters: {
-            account,
-            notification_template: notificationsTemplateFilter(push)
+            $or: [
+              { account, notification_template: templateFilter },
+              { account: account.toLowerCase(), notification_template: templateFilter },
+            ]
           },
           populate: NOTIFICATIONS_POPULATE
         }


### PR DESCRIPTION
`/api/notification-list` endpoint was not considering different cases for `account` parameter.
Now it select notifications for both original and lowercased.