### PR TITLE
feat: allow list solver flag

### DIFF
--- a/src/api/solver-network/content-types/solver-network/schema.json
+++ b/src/api/solver-network/content-types/solver-network/schema.json
@@ -41,6 +41,11 @@
       "type": "relation",
       "relation": "oneToOne",
       "target": "api::environment.environment"
+    },
+    "allowListed": {
+      "type": "boolean",
+      "default": false,
+      "required": true
     }
   }
 }

--- a/src/api/solver/content-types/solver/schema.json
+++ b/src/api/solver/content-types/solver/schema.json
@@ -16,11 +16,6 @@
       "type": "string",
       "required": true
     },
-    "active": {
-      "type": "boolean",
-      "default": true,
-      "required": true
-    },
     "image": {
       "type": "media",
       "multiple": false,

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-01-06T16:20:28.828Z"
+    "x-generation-date": "2025-01-06T16:25:21.759Z"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -241,9 +241,6 @@
                                                 "properties": {
                                                   "displayName": {
                                                     "type": "string"
-                                                  },
-                                                  "active": {
-                                                    "type": "boolean"
                                                   },
                                                   "image": {
                                                     "type": "object",
@@ -6653,9 +6650,6 @@
                                     "properties": {
                                       "displayName": {
                                         "type": "string"
-                                      },
-                                      "active": {
-                                        "type": "boolean"
                                       },
                                       "image": {
                                         "type": "object",
@@ -14792,9 +14786,6 @@
                                     "displayName": {
                                       "type": "string"
                                     },
-                                    "active": {
-                                      "type": "boolean"
-                                    },
                                     "image": {
                                       "type": "object",
                                       "properties": {
@@ -20678,16 +20669,12 @@
           "data": {
             "required": [
               "displayName",
-              "active",
               "solverId"
             ],
             "type": "object",
             "properties": {
               "displayName": {
                 "type": "string"
-              },
-              "active": {
-                "type": "boolean"
               },
               "image": {
                 "oneOf": [
@@ -20794,15 +20781,11 @@
         "type": "object",
         "required": [
           "displayName",
-          "active",
           "solverId"
         ],
         "properties": {
           "displayName": {
             "type": "string"
-          },
-          "active": {
-            "type": "boolean"
           },
           "image": {
             "type": "object",
@@ -21465,9 +21448,6 @@
                                   "properties": {
                                     "displayName": {
                                       "type": "string"
-                                    },
-                                    "active": {
-                                      "type": "boolean"
                                     },
                                     "image": {
                                       "type": "object",
@@ -22335,9 +22315,6 @@
                                                 "properties": {
                                                   "displayName": {
                                                     "type": "string"
-                                                  },
-                                                  "active": {
-                                                    "type": "boolean"
                                                   },
                                                   "image": {
                                                     "type": "object",
@@ -23594,9 +23571,6 @@
                     "properties": {
                       "displayName": {
                         "type": "string"
-                      },
-                      "active": {
-                        "type": "boolean"
                       },
                       "image": {
                         "type": "object",
@@ -26862,9 +26836,6 @@
                                               "properties": {
                                                 "displayName": {
                                                   "type": "string"
-                                                },
-                                                "active": {
-                                                  "type": "boolean"
                                                 },
                                                 "image": {
                                                   "type": "object",

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2024-12-16T11:10:37.171Z"
+    "x-generation-date": "2025-01-06T16:20:28.828Z"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -1207,6 +1207,9 @@
                                             }
                                           }
                                         }
+                                      },
+                                      "allowListed": {
+                                        "type": "boolean"
                                       },
                                       "createdAt": {
                                         "type": "string",
@@ -7224,6 +7227,9 @@
                                                           }
                                                         }
                                                       }
+                                                    },
+                                                    "allowListed": {
+                                                      "type": "boolean"
                                                     },
                                                     "createdAt": {
                                                       "type": "string",
@@ -15821,6 +15827,9 @@
                             }
                           }
                         },
+                        "allowListed": {
+                          "type": "boolean"
+                        },
                         "createdAt": {
                           "type": "string",
                           "format": "date-time"
@@ -22010,6 +22019,9 @@
                             }
                           }
                         },
+                        "allowListed": {
+                          "type": "boolean"
+                        },
                         "createdAt": {
                           "type": "string",
                           "format": "date-time"
@@ -23149,6 +23161,9 @@
                                                                     }
                                                                   }
                                                                 },
+                                                                "allowListed": {
+                                                                  "type": "boolean"
+                                                                },
                                                                 "createdAt": {
                                                                   "type": "string",
                                                                   "format": "date-time"
@@ -23458,7 +23473,8 @@
         "properties": {
           "data": {
             "required": [
-              "active"
+              "active",
+              "allowListed"
             ],
             "type": "object",
             "properties": {
@@ -23503,6 +23519,9 @@
                   }
                 ],
                 "example": "string or id"
+              },
+              "allowListed": {
+                "type": "boolean"
               }
             }
           }
@@ -23557,7 +23576,8 @@
       "SolverNetwork": {
         "type": "object",
         "required": [
-          "active"
+          "active",
+          "allowListed"
         ],
         "properties": {
           "solver": {
@@ -24400,6 +24420,9 @@
                                         }
                                       }
                                     },
+                                    "allowListed": {
+                                      "type": "boolean"
+                                    },
                                     "createdAt": {
                                       "type": "string",
                                       "format": "date-time"
@@ -24712,6 +24735,9 @@
                 }
               }
             }
+          },
+          "allowListed": {
+            "type": "boolean"
           },
           "createdAt": {
             "type": "string",
@@ -27802,6 +27828,9 @@
                                           }
                                         }
                                       }
+                                    },
+                                    "allowListed": {
+                                      "type": "boolean"
                                     },
                                     "createdAt": {
                                       "type": "string",


### PR DESCRIPTION
# Summary

2 changes:

1. Add `allowListed` to SolverNetwork model

Use this to indicate whether the given solver has been allow-listed for this network/env.

2. Remove `active` from Solver model

SolverNetwork also has an `active` flag that's used to indicate whether given solver is active for network/env.
This flag is a n artifact of a previous iteration of the model and should be removed.

|| Before | After|
|-|-|-|
|SolverNetwork|![image](https://github.com/user-attachments/assets/a576e273-451d-4652-a50b-ba1c7435a067)|![image](https://github.com/user-attachments/assets/b5806054-6b7f-4799-8878-0cac456f9bc6)|
|Solver|![image](https://github.com/user-attachments/assets/e1b28b46-7968-4258-8522-07ddbe171ede)|![image](https://github.com/user-attachments/assets/ee8fdd51-3737-4413-a729-17ffc364e684)|