### PR TITLE
feat: Update solver models to include vouching, whitelisting, and service fee

### DIFF
--- a/src/api/solver-bonding-pool/content-types/solver-bonding-pool/schema.json
+++ b/src/api/solver-bonding-pool/content-types/solver-bonding-pool/schema.json
@@ -34,7 +34,9 @@
       "inversedBy": "solver_bonding_pools"
     },
     "isReducedBondingPool": {
-      "type": "boolean"
+      "type": "boolean",
+      "required": true,
+      "default": false
     }
   }
 }

--- a/src/api/solver-bonding-pool/content-types/solver-bonding-pool/schema.json
+++ b/src/api/solver-bonding-pool/content-types/solver-bonding-pool/schema.json
@@ -4,7 +4,8 @@
   "info": {
     "singularName": "solver-bonding-pool",
     "pluralName": "solver-bonding-pools",
-    "displayName": "Solver Bonding Pool"
+    "displayName": "Solver Bonding Pool",
+    "description": ""
   },
   "options": {
     "draftAndPublish": false
@@ -31,6 +32,9 @@
       "relation": "manyToMany",
       "target": "api::solver.solver",
       "inversedBy": "solver_bonding_pools"
+    },
+    "isReducedBondingPool": {
+      "type": "boolean"
     }
   }
 }

--- a/src/api/solver-network/content-types/solver-network/schema.json
+++ b/src/api/solver-network/content-types/solver-network/schema.json
@@ -43,10 +43,12 @@
       "target": "api::environment.environment"
     },
     "isWhiteListed": {
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "isVouched": {
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/src/api/solver-network/content-types/solver-network/schema.json
+++ b/src/api/solver-network/content-types/solver-network/schema.json
@@ -41,6 +41,12 @@
       "type": "relation",
       "relation": "oneToOne",
       "target": "api::environment.environment"
+    },
+    "isWhiteListed": {
+      "type": "boolean"
+    },
+    "isVouched": {
+      "type": "boolean"
     }
   }
 }

--- a/src/api/solver-network/content-types/solver-network/schema.json
+++ b/src/api/solver-network/content-types/solver-network/schema.json
@@ -49,6 +49,11 @@
     "isVouched": {
       "type": "boolean",
       "default": false
+    },
+    "isColocated": {
+      "type": "boolean",
+      "default": false,
+      "required": true
     }
   }
 }

--- a/src/api/solver/content-types/solver/schema.json
+++ b/src/api/solver/content-types/solver/schema.json
@@ -54,6 +54,9 @@
       "relation": "manyToMany",
       "target": "api::solver-bonding-pool.solver-bonding-pool",
       "mappedBy": "solvers"
+    },
+    "isServiceFeeEnabled": {
+      "type": "boolean"
     }
   }
 }

--- a/src/api/solver/content-types/solver/schema.json
+++ b/src/api/solver/content-types/solver/schema.json
@@ -59,6 +59,16 @@
       "type": "boolean",
       "required": true,
       "default": false
+    },
+    "isColocated": {
+      "type": "enumeration",
+      "enum": [
+        "Yes",
+        "No",
+        "Partial"
+      ],
+      "required": true,
+      "default": "No"
     }
   }
 }

--- a/src/api/solver/content-types/solver/schema.json
+++ b/src/api/solver/content-types/solver/schema.json
@@ -56,7 +56,9 @@
       "mappedBy": "solvers"
     },
     "isServiceFeeEnabled": {
-      "type": "boolean"
+      "type": "boolean",
+      "required": true,
+      "default": false
     }
   }
 }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -1077,6 +1077,14 @@
                                                   "isServiceFeeEnabled": {
                                                     "type": "boolean"
                                                   },
+                                                  "isColocated": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "Yes",
+                                                      "No",
+                                                      "Partial"
+                                                    ]
+                                                  },
                                                   "createdAt": {
                                                     "type": "string",
                                                     "format": "date-time"
@@ -1218,6 +1226,9 @@
                                         "type": "boolean"
                                       },
                                       "isVouched": {
+                                        "type": "boolean"
+                                      },
+                                      "isColocated": {
                                         "type": "boolean"
                                       },
                                       "createdAt": {
@@ -7243,6 +7254,9 @@
                                                     "isVouched": {
                                                       "type": "boolean"
                                                     },
+                                                    "isColocated": {
+                                                      "type": "boolean"
+                                                    },
                                                     "createdAt": {
                                                       "type": "string",
                                                       "format": "date-time"
@@ -7314,6 +7328,14 @@
                                       },
                                       "isServiceFeeEnabled": {
                                         "type": "boolean"
+                                      },
+                                      "isColocated": {
+                                        "type": "string",
+                                        "enum": [
+                                          "Yes",
+                                          "No",
+                                          "Partial"
+                                        ]
                                       },
                                       "createdAt": {
                                         "type": "string",
@@ -16908,6 +16930,14 @@
                                     "isServiceFeeEnabled": {
                                       "type": "boolean"
                                     },
+                                    "isColocated": {
+                                      "type": "string",
+                                      "enum": [
+                                        "Yes",
+                                        "No",
+                                        "Partial"
+                                      ]
+                                    },
                                     "createdAt": {
                                       "type": "string",
                                       "format": "date-time"
@@ -17118,6 +17148,9 @@
                           "type": "boolean"
                         },
                         "isVouched": {
+                          "type": "boolean"
+                        },
+                        "isColocated": {
                           "type": "boolean"
                         },
                         "createdAt": {
@@ -21970,7 +22003,8 @@
               "displayName",
               "active",
               "solverId",
-              "isServiceFeeEnabled"
+              "isServiceFeeEnabled",
+              "isColocated"
             ],
             "type": "object",
             "properties": {
@@ -22033,6 +22067,14 @@
               },
               "isServiceFeeEnabled": {
                 "type": "boolean"
+              },
+              "isColocated": {
+                "type": "string",
+                "enum": [
+                  "Yes",
+                  "No",
+                  "Partial"
+                ]
               }
             }
           }
@@ -22090,7 +22132,8 @@
           "displayName",
           "active",
           "solverId",
-          "isServiceFeeEnabled"
+          "isServiceFeeEnabled",
+          "isColocated"
         ],
         "properties": {
           "displayName": {
@@ -23114,6 +23157,14 @@
                                     "isServiceFeeEnabled": {
                                       "type": "boolean"
                                     },
+                                    "isColocated": {
+                                      "type": "string",
+                                      "enum": [
+                                        "Yes",
+                                        "No",
+                                        "Partial"
+                                      ]
+                                    },
                                     "createdAt": {
                                       "type": "string",
                                       "format": "date-time"
@@ -23326,6 +23377,9 @@
                         "isVouched": {
                           "type": "boolean"
                         },
+                        "isColocated": {
+                          "type": "boolean"
+                        },
                         "createdAt": {
                           "type": "string",
                           "format": "date-time"
@@ -23397,6 +23451,14 @@
           },
           "isServiceFeeEnabled": {
             "type": "boolean"
+          },
+          "isColocated": {
+            "type": "string",
+            "enum": [
+              "Yes",
+              "No",
+              "Partial"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -24479,6 +24541,9 @@
                                                                 "isVouched": {
                                                                   "type": "boolean"
                                                                 },
+                                                                "isColocated": {
+                                                                  "type": "boolean"
+                                                                },
                                                                 "createdAt": {
                                                                   "type": "string",
                                                                   "format": "date-time"
@@ -24550,6 +24615,14 @@
                                                   },
                                                   "isServiceFeeEnabled": {
                                                     "type": "boolean"
+                                                  },
+                                                  "isColocated": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "Yes",
+                                                      "No",
+                                                      "Partial"
+                                                    ]
                                                   },
                                                   "createdAt": {
                                                     "type": "string",
@@ -24797,7 +24870,8 @@
         "properties": {
           "data": {
             "required": [
-              "active"
+              "active",
+              "isColocated"
             ],
             "type": "object",
             "properties": {
@@ -24847,6 +24921,9 @@
                 "type": "boolean"
               },
               "isVouched": {
+                "type": "boolean"
+              },
+              "isColocated": {
                 "type": "boolean"
               }
             }
@@ -24902,7 +24979,8 @@
       "SolverNetwork": {
         "type": "object",
         "required": [
-          "active"
+          "active",
+          "isColocated"
         ],
         "properties": {
           "solver": {
@@ -25751,6 +25829,9 @@
                                     "isVouched": {
                                       "type": "boolean"
                                     },
+                                    "isColocated": {
+                                      "type": "boolean"
+                                    },
                                     "createdAt": {
                                       "type": "string",
                                       "format": "date-time"
@@ -25979,6 +26060,14 @@
                       "isServiceFeeEnabled": {
                         "type": "boolean"
                       },
+                      "isColocated": {
+                        "type": "string",
+                        "enum": [
+                          "Yes",
+                          "No",
+                          "Partial"
+                        ]
+                      },
                       "createdAt": {
                         "type": "string",
                         "format": "date-time"
@@ -26074,6 +26163,9 @@
             "type": "boolean"
           },
           "isVouched": {
+            "type": "boolean"
+          },
+          "isColocated": {
             "type": "boolean"
           },
           "createdAt": {
@@ -29035,6 +29127,14 @@
                                                 "isServiceFeeEnabled": {
                                                   "type": "boolean"
                                                 },
+                                                "isColocated": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "Yes",
+                                                    "No",
+                                                    "Partial"
+                                                  ]
+                                                },
                                                 "createdAt": {
                                                   "type": "string",
                                                   "format": "date-time"
@@ -29176,6 +29276,9 @@
                                       "type": "boolean"
                                     },
                                     "isVouched": {
+                                      "type": "boolean"
+                                    },
+                                    "isColocated": {
                                       "type": "boolean"
                                     },
                                     "createdAt": {

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -1022,6 +1022,9 @@
                                                                     }
                                                                   }
                                                                 },
+                                                                "isReducedBondingPool": {
+                                                                  "type": "boolean"
+                                                                },
                                                                 "createdAt": {
                                                                   "type": "string",
                                                                   "format": "date-time"
@@ -1070,6 +1073,9 @@
                                                         }
                                                       }
                                                     }
+                                                  },
+                                                  "isServiceFeeEnabled": {
+                                                    "type": "boolean"
                                                   },
                                                   "createdAt": {
                                                     "type": "string",
@@ -1207,6 +1213,12 @@
                                             }
                                           }
                                         }
+                                      },
+                                      "isWhiteListed": {
+                                        "type": "boolean"
+                                      },
+                                      "isVouched": {
+                                        "type": "boolean"
                                       },
                                       "createdAt": {
                                         "type": "string",
@@ -7225,6 +7237,12 @@
                                                         }
                                                       }
                                                     },
+                                                    "isWhiteListed": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "isVouched": {
+                                                      "type": "boolean"
+                                                    },
                                                     "createdAt": {
                                                       "type": "string",
                                                       "format": "date-time"
@@ -7294,6 +7312,9 @@
                                           }
                                         }
                                       },
+                                      "isServiceFeeEnabled": {
+                                        "type": "boolean"
+                                      },
                                       "createdAt": {
                                         "type": "string",
                                         "format": "date-time"
@@ -7342,6 +7363,9 @@
                               }
                             }
                           }
+                        },
+                        "isReducedBondingPool": {
+                          "type": "boolean"
                         },
                         "createdAt": {
                           "type": "string",
@@ -16829,6 +16853,9 @@
                                                       }
                                                     }
                                                   },
+                                                  "isReducedBondingPool": {
+                                                    "type": "boolean"
+                                                  },
                                                   "createdAt": {
                                                     "type": "string",
                                                     "format": "date-time"
@@ -16877,6 +16904,9 @@
                                           }
                                         }
                                       }
+                                    },
+                                    "isServiceFeeEnabled": {
+                                      "type": "boolean"
                                     },
                                     "createdAt": {
                                       "type": "string",
@@ -17083,6 +17113,12 @@
                               }
                             }
                           }
+                        },
+                        "isWhiteListed": {
+                          "type": "boolean"
+                        },
+                        "isVouched": {
+                          "type": "boolean"
                         },
                         "createdAt": {
                           "type": "string",
@@ -21993,6 +22029,9 @@
                   ],
                   "example": "string or id"
                 }
+              },
+              "isServiceFeeEnabled": {
+                "type": "boolean"
               }
             }
           }
@@ -23018,6 +23057,9 @@
                                                       }
                                                     }
                                                   },
+                                                  "isReducedBondingPool": {
+                                                    "type": "boolean"
+                                                  },
                                                   "createdAt": {
                                                     "type": "string",
                                                     "format": "date-time"
@@ -23066,6 +23108,9 @@
                                           }
                                         }
                                       }
+                                    },
+                                    "isServiceFeeEnabled": {
+                                      "type": "boolean"
                                     },
                                     "createdAt": {
                                       "type": "string",
@@ -23273,6 +23318,12 @@
                             }
                           }
                         },
+                        "isWhiteListed": {
+                          "type": "boolean"
+                        },
+                        "isVouched": {
+                          "type": "boolean"
+                        },
                         "createdAt": {
                           "type": "string",
                           "format": "date-time"
@@ -23341,6 +23392,9 @@
                 }
               }
             }
+          },
+          "isServiceFeeEnabled": {
+            "type": "boolean"
           },
           "createdAt": {
             "type": "string",
@@ -23452,6 +23506,9 @@
                   ],
                   "example": "string or id"
                 }
+              },
+              "isReducedBondingPool": {
+                "type": "boolean"
               }
             }
           }
@@ -24412,6 +24469,12 @@
                                                                     }
                                                                   }
                                                                 },
+                                                                "isWhiteListed": {
+                                                                  "type": "boolean"
+                                                                },
+                                                                "isVouched": {
+                                                                  "type": "boolean"
+                                                                },
                                                                 "createdAt": {
                                                                   "type": "string",
                                                                   "format": "date-time"
@@ -24481,6 +24544,9 @@
                                                       }
                                                     }
                                                   },
+                                                  "isServiceFeeEnabled": {
+                                                    "type": "boolean"
+                                                  },
                                                   "createdAt": {
                                                     "type": "string",
                                                     "format": "date-time"
@@ -24529,6 +24595,9 @@
                                           }
                                         }
                                       }
+                                    },
+                                    "isReducedBondingPool": {
+                                      "type": "boolean"
                                     },
                                     "createdAt": {
                                       "type": "string",
@@ -24646,6 +24715,9 @@
                 }
               }
             }
+          },
+          "isReducedBondingPool": {
+            "type": "boolean"
           },
           "createdAt": {
             "type": "string",
@@ -24766,6 +24838,12 @@
                   }
                 ],
                 "example": "string or id"
+              },
+              "isWhiteListed": {
+                "type": "boolean"
+              },
+              "isVouched": {
+                "type": "boolean"
               }
             }
           }
@@ -25663,6 +25741,12 @@
                                         }
                                       }
                                     },
+                                    "isWhiteListed": {
+                                      "type": "boolean"
+                                    },
+                                    "isVouched": {
+                                      "type": "boolean"
+                                    },
                                     "createdAt": {
                                       "type": "string",
                                       "format": "date-time"
@@ -25836,6 +25920,9 @@
                                         }
                                       }
                                     },
+                                    "isReducedBondingPool": {
+                                      "type": "boolean"
+                                    },
                                     "createdAt": {
                                       "type": "string",
                                       "format": "date-time"
@@ -25884,6 +25971,9 @@
                             }
                           }
                         }
+                      },
+                      "isServiceFeeEnabled": {
+                        "type": "boolean"
                       },
                       "createdAt": {
                         "type": "string",
@@ -25975,6 +26065,12 @@
                 }
               }
             }
+          },
+          "isWhiteListed": {
+            "type": "boolean"
+          },
+          "isVouched": {
+            "type": "boolean"
           },
           "createdAt": {
             "type": "string",
@@ -28880,6 +28976,9 @@
                                                                   }
                                                                 }
                                                               },
+                                                              "isReducedBondingPool": {
+                                                                "type": "boolean"
+                                                              },
                                                               "createdAt": {
                                                                 "type": "string",
                                                                 "format": "date-time"
@@ -28928,6 +29027,9 @@
                                                       }
                                                     }
                                                   }
+                                                },
+                                                "isServiceFeeEnabled": {
+                                                  "type": "boolean"
                                                 },
                                                 "createdAt": {
                                                   "type": "string",
@@ -29065,6 +29167,12 @@
                                           }
                                         }
                                       }
+                                    },
+                                    "isWhiteListed": {
+                                      "type": "boolean"
+                                    },
+                                    "isVouched": {
+                                      "type": "boolean"
                                     },
                                     "createdAt": {
                                       "type": "string",

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -21969,7 +21969,8 @@
             "required": [
               "displayName",
               "active",
-              "solverId"
+              "solverId",
+              "isServiceFeeEnabled"
             ],
             "type": "object",
             "properties": {
@@ -22088,7 +22089,8 @@
         "required": [
           "displayName",
           "active",
-          "solverId"
+          "solverId",
+          "isServiceFeeEnabled"
         ],
         "properties": {
           "displayName": {
@@ -23471,7 +23473,8 @@
           "data": {
             "required": [
               "address",
-              "joinedOn"
+              "joinedOn",
+              "isReducedBondingPool"
             ],
             "type": "object",
             "properties": {
@@ -23564,7 +23567,8 @@
         "type": "object",
         "required": [
           "address",
-          "joinedOn"
+          "joinedOn",
+          "isReducedBondingPool"
         ],
         "properties": {
           "address": {


### PR DESCRIPTION
This PR extends #48 to include both whitelisting and vouching information on the solver-network relation. It also updates the solver-bonding-pool relation to indicate whether it is a full bonding pool or a reduced bonding pool and updates the solver model to indicate whether or not the solver pays a service fee.

It also adds flags to the solver-network and solver models to indicate whether a solver is colocated and whether a solver's address is colocated.

![image](https://github.com/user-attachments/assets/347d79ff-0123-4287-bb38-dc9c95e80ded)
![image](https://github.com/user-attachments/assets/90a2fb39-0bd3-4add-8a62-48cdf9a84dec)
![image](https://github.com/user-attachments/assets/3143f3df-faae-403e-9366-1b552d12a104)
