### PR TITLE
feat: allow Tax Free Assets to be a draft before publishing

### DIFF
--- a/src/api/tax-free-asset/content-types/tax-free-asset/schema.json
+++ b/src/api/tax-free-asset/content-types/tax-free-asset/schema.json
@@ -8,7 +8,7 @@
     "description": ""
   },
   "options": {
-    "draftAndPublish": false
+    "draftAndPublish": true
   },
   "pluginOptions": {},
   "attributes": {

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2024-12-16T11:10:37.171Z"
+    "x-generation-date": "2025-02-07T14:35:19.279Z"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -27905,6 +27905,10 @@
             "format": "date-time"
           },
           "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "publishedAt": {
             "type": "string",
             "format": "date-time"
           },


### PR DESCRIPTION
# Summary

Using the built-in `draft` state for `Tax Free Assets` model.

This way a manual inspection is required before enabling any entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled a draft & publish workflow for tax-free asset content, allowing users to save content as drafts before final publishing.
	- Introduced a publication timestamp to help track when documents are published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->