### PR TITLE
chore: set server timeout 2 mins

### DIFF
--- a/config/server.ts
+++ b/config/server.ts
@@ -4,6 +4,11 @@ export default ({ env }) => ({
   app: {
     keys: env.array('APP_KEYS'),
   },
+  http: {
+    serverOptions: {
+      timeout: 120_000, // 2 minutes
+    },
+  },
   webhooks: {
     populateRelations: env.bool('WEBHOOKS_POPULATE_RELATIONS', false),
   },


### PR DESCRIPTION
Marketing is trying to upload a big file of notifications and the request gets failed every time because of 504 http error.
In order to fix that, I've increased the server timeout limit up to 2 mins.

https://www.linkedin.com/pulse/extending-request-timeout-strapi-quick-configuration-guide-pathak-ykdxc/