### PR TITLE
feat: use text rather than string for tokenIds field type

### DIFF
--- a/src/api/tax-free-asset/content-types/tax-free-asset/schema.json
+++ b/src/api/tax-free-asset/content-types/tax-free-asset/schema.json
@@ -16,7 +16,7 @@
       "type": "string"
     },
     "tokenIds": {
-      "type": "string",
+      "type": "text",
       "required": true
     },
     "chainId": {

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2024-12-16T11:10:37.171Z"
+    "x-generation-date": "2025-02-11T18:27:39.661Z"
   },
   "x-strapi-config": {
     "path": "/documentation",


### PR DESCRIPTION
# Summary

While locally there are no issues, inserting long values into `tokenIds` field causes the operation to fail
![image](https://github.com/user-attachments/assets/460f5055-70f4-473a-be1a-485e1f38e166)

The max char length of the string field is 255, while the text field has no limits.