### PR TITLE
feat: manually trigger notification

### DIFF
--- a/config/cron-tasks.ts
+++ b/config/cron-tasks.ts
@@ -4,49 +4,9 @@ export default {
    */
   cleanupExpiredNotifications: {
     task: async ({ strapi }) => {
-      console.log("Running cleanupExpiredNotifications task");
-      try {
-        // Calculate date 1 week ago
-        const oneWeekAgo = new Date();
-        oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
-
-        // Find all notifications with templates due over a week ago
-        const expiredNotifications = await strapi.db
-          .query("api::notification.notification")
-          .findMany({
-            where: {
-              $or: [
-                {
-                  notification_template: {
-                    dueDate: {
-                      $lt: oneWeekAgo,
-                    },
-                  },
-                },
-                {
-                  notification_template: null,
-                },
-              ],
-            },
-          });
-
-        // Delete the expired and orphaned notifications
-        if (expiredNotifications.length > 0) {
-          await strapi.db.query("api::notification.notification").deleteMany({
-            where: {
-              id: {
-                $in: expiredNotifications.map((n) => n.id),
-              },
-            },
-          });
-          console.log(
-            `Deleted ${expiredNotifications.length} notifications that were over a week past due or orphaned`
-          );
-        }
-      } catch (error) {
-        console.error("Error cleaning up notifications:", error);
-      }
-      console.log("Finished cleanupExpiredNotifications task");
+      await strapi
+        .service("api::notification.cleanup")
+        .cleanupExpiredNotifications();
     },
     options: {
       rule: "0 0 * * *", // Runs daily at midnight

--- a/src/api/notification/controllers/cleanup.ts
+++ b/src/api/notification/controllers/cleanup.ts
@@ -1,0 +1,13 @@
+export default {
+  async cleanupExpiredNotifications(ctx) {
+    try {
+      const result = await strapi
+        .service("api::notification.cleanup")
+        .cleanupExpiredNotifications();
+
+      return { data: result };
+    } catch (error) {
+      ctx.throw(500, error);
+    }
+  },
+};

--- a/src/api/notification/routes/cleanup.ts
+++ b/src/api/notification/routes/cleanup.ts
@@ -1,0 +1,13 @@
+module.exports = {
+  routes: [
+    {
+      method: "POST",
+      path: "/notifications/cleanup",
+      handler: "cleanup.cleanupExpiredNotifications",
+      config: {
+        policies: [],
+        middlewares: [],
+      },
+    },
+  ],
+};

--- a/src/api/notification/services/cleanup.ts
+++ b/src/api/notification/services/cleanup.ts
@@ -1,0 +1,50 @@
+export default {
+  async cleanupExpiredNotifications() {
+    console.log("Running cleanupExpiredNotifications task");
+    try {
+      // Calculate date 1 week ago
+      const oneWeekAgo = new Date();
+      oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+
+      // Find all notifications with templates due over a week ago
+      const expiredNotifications = await strapi.db
+        .query("api::notification.notification")
+        .findMany({
+          where: {
+            $or: [
+              {
+                notification_template: {
+                  dueDate: {
+                    $lt: oneWeekAgo,
+                  },
+                },
+              },
+              {
+                notification_template: null,
+              },
+            ],
+          },
+        });
+
+      // Delete the expired and orphaned notifications
+      if (expiredNotifications.length > 0) {
+        await strapi.db.query("api::notification.notification").deleteMany({
+          where: {
+            id: {
+              $in: expiredNotifications.map((n) => n.id),
+            },
+          },
+        });
+        console.log(
+          `Deleted ${expiredNotifications.length} notifications that were over a week past due or orphaned`
+        );
+      }
+      console.log("Finished cleanupExpiredNotifications task");
+
+      return { success: true, deletedCount: expiredNotifications.length };
+    } catch (error) {
+      console.error("Error cleaning up notifications:", error);
+      return { success: false, error: error.message };
+    }
+  },
+};

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-03-11T10:10:29.665Z"
+    "x-generation-date": "2025-03-13T18:32:30.099Z"
   },
   "x-strapi-config": {
     "path": "/documentation",


### PR DESCRIPTION
# Summary

Add a way to manually trigger the notification clean up.
The cronjob has been added for a few days, but the notifications had not been cleaned up.

Since the strapi cloud logs are quite bad to navigate, this should give instant feedback on what's wrong.

# Testing

1. Create a new API token with the permission `Notification > cleanup > cleanupExpiredNotifications`: 
![image](https://github.com/user-attachments/assets/3b3c59b6-33ee-4642-8c3c-842c07f47fbb)
2. Make POST request containing the header: `authorization: bearer <api key>`
* The request should succeed and return the response.

Example of a successful response:

```
{
    "data": {
        "success": true,
        "deletedCount": 0
    }
}
```

Example of an error response:
```
{
    "data": {
        "success": false,
        "error": "This is a test error"
    }
}
```
