### PR TITLE
feat: delete notifications in batches of 1k

### DIFF
--- a/src/api/notification/services/cleanup.ts
+++ b/src/api/notification/services/cleanup.ts
@@ -26,17 +26,31 @@ export default {
           },
         });
 
-      // Delete the expired and orphaned notifications
+      // Delete the expired and orphaned notifications in batches
       if (expiredNotifications.length > 0) {
-        await strapi.db.query("api::notification.notification").deleteMany({
-          where: {
-            id: {
-              $in: expiredNotifications.map((n) => n.id),
+        const BATCH_SIZE = 1000;
+        let totalDeleted = 0;
+
+        // Process in batches
+        for (let i = 0; i < expiredNotifications.length; i += BATCH_SIZE) {
+          const batch = expiredNotifications.slice(i, i + BATCH_SIZE);
+          await strapi.db.query("api::notification.notification").deleteMany({
+            where: {
+              id: {
+                $in: batch.map((n) => n.id),
+              },
             },
-          },
-        });
+          });
+          totalDeleted += batch.length;
+          console.log(
+            `Processed batch: ${i / BATCH_SIZE + 1}, Deleted: ${
+              batch.length
+            } notifications`
+          );
+        }
+
         console.log(
-          `Deleted ${expiredNotifications.length} notifications that were over a week past due or orphaned`
+          `Deleted ${totalDeleted} notifications that were over a week past due or orphaned`
         );
       }
       console.log("Finished cleanupExpiredNotifications task");


### PR DESCRIPTION
# Summary

After https://github.com/cowprotocol/cms/pull/58, it's possible to see that the cleanup is failing because too much is being deleted at once.

This change splits it into 1k batches.

# Testing

Same as #58 