### PR TITLE
feat: check telegram subscriptions

### DIFF
--- a/src/api/telegram-subscription/controllers/telegram-subscription.ts
+++ b/src/api/telegram-subscription/controllers/telegram-subscription.ts
@@ -15,19 +15,39 @@ export default factories.createCoreController(MODULE_ID, ({strapi}) => {
 
       const service = strapi.service(MODULE_ID)
 
-      const existing = await strapi.entityService.findMany(MODULE_ID, { filters: { account, chatId: data.id } })
+      const isAlreadySubscribed = await this.checkSubscription(context)
 
-      if (existing.length > 0) return true
-
-      const result = await service.verifyTgAuthentication(data)
-
-      if (!result) {
-        throw new errors.ValidationError('Invalid telegram authentication data')
+      if (isAlreadySubscribed) {
+        return true
       }
 
       await service.addSubscription(account, data)
 
       return true
+    },
+    async checkSubscription(context) {
+      const {account, data} : { account: string, data: TelegramData } = context.request.body
+
+      const service = strapi.service(MODULE_ID)
+
+      const result = await service.verifyTgAuthentication(data)
+
+      /**
+       * Verify if the Telegram authentication data is valid
+       * Which proves that the data belongs to the user
+       */
+      if (!result) {
+        throw new errors.ValidationError('Invalid telegram authentication data')
+      }
+
+      const existing = await strapi.entityService.findMany(MODULE_ID, { filters: { account, chatId: data.id } })
+
+      /**
+       * We will only return true if the subscription belongs to the Telegram owner
+       * And the account is already subscribed
+       * So, it's not possible to check another account's subscription without owning Telegram account
+       */
+      return existing.length > 0
     },
     async getSubscriptions(context) {
       const { accounts } = context.query

--- a/src/api/telegram-subscription/routes/telegram-subscription.ts
+++ b/src/api/telegram-subscription/routes/telegram-subscription.ts
@@ -48,6 +48,15 @@ const myExtraRoutes = [
     },
   },
   {
+    method: 'POST',
+    path: '/check-tg-subscription',
+    handler: 'telegram-subscription.checkSubscription',
+    config: {
+      policies: [],
+      middlewares: [],
+    },
+  },
+  {
     method: 'GET',
     path: '/send-tg-notifications',
     handler: 'telegram-subscription.sendNotifications',

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-03-13T18:32:30.099Z"
+    "x-generation-date": "2025-04-16T15:57:18.119Z"
   },
   "x-strapi-config": {
     "path": "/documentation",


### PR DESCRIPTION
We need a method to check if a given blockchain account already subscribed to the Telegram account.
We already have this check in `addSubscription`, just moved it to a separate method in order to call the check before adding subscription.