### PR TITLE
feat(notifications): add subscription removal method

### DIFF
--- a/src/api/telegram-subscription/controllers/telegram-subscription.ts
+++ b/src/api/telegram-subscription/controllers/telegram-subscription.ts
@@ -25,6 +25,21 @@ export default factories.createCoreController(MODULE_ID, ({strapi}) => {
 
       return true
     },
+    async removeSubscription(context) {
+      const {account} : { account: string, data: TelegramData } = context.request.body
+
+      const service = strapi.service(MODULE_ID)
+
+      const isAlreadySubscribed = await this.checkSubscription(context)
+
+      if (!isAlreadySubscribed) {
+        return true
+      }
+
+      await service.removeSubscriptions(account)
+
+      return true
+    },
     async checkSubscription(context) {
       const {account, data} : { account: string, data: TelegramData } = context.request.body
 

--- a/src/api/telegram-subscription/routes/telegram-subscription.ts
+++ b/src/api/telegram-subscription/routes/telegram-subscription.ts
@@ -49,6 +49,15 @@ const myExtraRoutes = [
   },
   {
     method: 'POST',
+    path: '/remove-tg-subscription',
+    handler: 'telegram-subscription.removeSubscription',
+    config: {
+      policies: [],
+      middlewares: [],
+    },
+  },
+  {
+    method: 'POST',
     path: '/check-tg-subscription',
     handler: 'telegram-subscription.checkSubscription',
     config: {

--- a/src/api/telegram-subscription/services/telegram-subscription.ts
+++ b/src/api/telegram-subscription/services/telegram-subscription.ts
@@ -43,6 +43,15 @@ export default factories.createCoreService(MODULE_ID, ({strapi}) => {
           }
         })
     },
+    async removeSubscriptions(account: string) {
+      const subscriptions = await this.getAccountSubscriptions(account)
+
+      for (const subscription of subscriptions) {
+        await strapi.entityService.delete(MODULE_ID, subscription.id)
+      }
+
+      return true
+    },
     async getSubscriptions(accounts: string[]) {
       return strapi.entityService.findMany(
         MODULE_ID,

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-04-16T15:57:18.119Z"
+    "x-generation-date": "2025-09-02T08:30:05.698Z"
   },
   "x-strapi-config": {
     "path": "/documentation",


### PR DESCRIPTION
Added a new method to unsubscribe an account from Telegram notifications.
The method is protected with `checkSubscription`, so only when user has a valid TG authorization they can perform the unsubscription.