### PR TITLE
ci: setup npm trusted publisher

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,5 +1,9 @@
 name: Publish NPM Package
 
+permissions:
+  id-token: write
+
+
 on:
   workflow_dispatch: # Trigger manually through GitHub Actions interface
 
@@ -8,7 +12,7 @@ on:
       - "v*" # Trigger on version tags (e.g., v1.0.0)
 
 env:
-  NODE_VERSION: lts/hydrogen
+  NODE_VERSION: lts/jod
 
 jobs:
   publish:
@@ -26,10 +30,11 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://registry.npmjs.org"
 
+      # Upgrade npm for trusted publishing (requires npm >= 11.5.1)
+      - run: npm install -g npm@latest
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
       - name: Publish to npm
         run: scripts/publish-lib.sh
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/lib/package.json
+++ b/lib/package.json
@@ -2,6 +2,11 @@
   "name": "@cowprotocol/cms",
   "version": "*** THE VERSION IS OVERRIDDEN AT PUBLISHING TIME ***",
   "description": "Cow Protocol CMS",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cowprotocol/cms.git",
+    "directory": "lib"
+  },
   "main": "dist/lib.js",
   "types": "dist/lib.d.ts",
   "source": "src/lib.ts",

--- a/scripts/publish-lib.sh
+++ b/scripts/publish-lib.sh
@@ -29,4 +29,4 @@ yarn build:lib
 
 # Publish the library
 echo -e "\n🚀 Publish the library"
-(cd lib && npm publish --access public)
+(cd lib && npm publish --access public --provenance)


### PR DESCRIPTION
NPM doesn't allow generating write access tokens for longer than 3 months. For CI we should use `trushed published` instead:

- https://docs.npmjs.com/trusted-publishers
- https://philna.sh/blog/2026/01/28/trusted-publishing-npm/

I've already linked all the packages from this repo to the trusted publisher.